### PR TITLE
create well formed globi.json by adding "citation" field

### DIFF
--- a/globi.json
+++ b/globi.json
@@ -1,4 +1,4 @@
 { 
   "_comment": "Sample GloBI dataset descriptor. See http://github.com/globalbioticinteractions for more information.",
-  "Proceedings of the Entomological Society of Washington. http://biodiversitylibrary.org/page/16172717#page/332/mode/1up"
+  "citation": "Proceedings of the Entomological Society of Washington. http://biodiversitylibrary.org/page/16172717#page/332/mode/1up"
 }


### PR DESCRIPTION
@millerse I noticed that some `globi.json` do not contain the citation property. A minimal `globi.json` should like something like:

``` json
{ "citation" : "Jane Doe. 2015. Species interactions extracted from http://bla.com. " }
```

This pull request should fix one of them. Kindly, verify that others are also well formed.

This citation is then used to populate the source citation of the study. The study citation is provided in the `interactions.tsv` file. Please let me know if you have any other questions. Note that GloBI automatically append the source of the github repo and last accessed date to the source citation (e.g. 

For instance (with GloBI additions in **bold**):

Sarah E Miller. 3/4/2015. Species associations manually extracted from http://onlinelibrary.wiley.com/doi/10.1111/j.1474-919X.2009.00907.x/suppinfo. **Accessed at https://raw.githubusercontent.com/millerse/Weidinger-et-al.-2009/6711fa67a3aa51103c0c1aed16461d582a8aa46b/interactions.tsv on 07 Apr 2015.**

Please let me know if you have any questions. Thanks! -jorrit
